### PR TITLE
Fix incorrect point data when clicking map marker

### DIFF
--- a/src/views/sidepanels/ScopeFeatures.tsx
+++ b/src/views/sidepanels/ScopeFeatures.tsx
@@ -240,6 +240,7 @@ const ScopeFeatures: FC<ScopeFeaturesProps> = ({
   />;
 
   if (selectedPoint) return <ScopePoint
+    key={`${scopeId}-${selectedPoint}`}
     scopeId={scopeId}
     pointId={selectedPoint}
     isEditing={isPointEditing}


### PR DESCRIPTION
Add key prop to ScopePoint to force remount when selected point changes


https://github.com/user-attachments/assets/75f3c93d-b1e6-4bbb-9285-ccab781f83c5

